### PR TITLE
Fix import and upgrade caddyserver version to 1.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 go_import_path: github.com/lucaslorentz/caddy-supervisor
 
 go:
- - 1.9.x
+ - 1.13.x
 
 dist: trusty
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ example.com {
 ```
 
 ## Building it
-Build from caddy repository and import  **caddy-supervisor** plugin on file https://github.com/mholt/caddy/blob/master/caddy/caddymain/run.go :
+Build from caddy repository and import  **caddy-supervisor** plugin on file https://github.com/caddyserver/caddy/blob/master/caddy/caddymain/run.go :
 ```
 import (
   _ "github.com/lucaslorentz/caddy-supervisor/httpplugin"

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,8 +3,8 @@ import:
 - package: github.com/Masterminds/sprig
   version: master
 - package: github.com/hacdias/caddy-service
-- package: github.com/mholt/caddy
-  version: ^0.11.0
+- package: github.com/caddyserver/caddy
+  version: ^1.0.3
   subpackages:
   - caddy/caddymain
   - caddyfile

--- a/httpplugin/parser.go
+++ b/httpplugin/parser.go
@@ -2,7 +2,7 @@ package httpplugin
 
 import (
 	"github.com/lucaslorentz/caddy-supervisor/supervisor"
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 func parseHTTPDirectives(c *caddy.Controller) ([]*supervisor.Options, error) {

--- a/httpplugin/setup.go
+++ b/httpplugin/setup.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"github.com/lucaslorentz/caddy-supervisor/supervisor"
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	// Caddy
-	"github.com/mholt/caddy/caddy/caddymain"
+	"github.com/caddyserver/caddy/caddy/caddymain"
 
 	// Plugins
 	_ "github.com/hacdias/caddy-service"

--- a/servertype/setup.go
+++ b/servertype/setup.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 
 	"github.com/lucaslorentz/caddy-supervisor/supervisor"
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyfile"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyfile"
 )
 
 func init() {

--- a/supervisor/parser.go
+++ b/supervisor/parser.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 // ParseOption parses supervisor options


### PR DESCRIPTION
- Upgrade go version on travis 1.9.x -> 1.13.x
- Upgrade caddyserver  0.11.0 -> 1.0.3
- Fix caddy import `github.com/mholt/caddy` -> `github.com/caddyserver/caddy`

Error on build with latest version : 
```bash
go: finding github.com/lucaslorentz/caddy-supervisor/httpplugin latest
go: finding github.com/lucaslorentz/caddy-supervisor/servertype latest
go: finding github.com/mholt/caddy/caddy/caddymain latest
go: finding github.com/mholt/caddy/caddy latest
go: github.com/mholt/caddy@v1.0.3: parsing go.mod: unexpected module path "github.com/caddyserver/caddy"
go: error loading module requirements
```